### PR TITLE
fix: Only copy animations if they exist

### DIFF
--- a/.develop.sh
+++ b/.develop.sh
@@ -72,9 +72,11 @@ do_doc() {
     if ! python3 ./.pre_processing.py; then AN_ERROR_OCCURED=1; finish_up; return; fi
   fi
   if ! sphinx-build -E -a . ./_html; then AN_ERROR_OCCURED=1; finish_up; return; fi
-
-  if [ ! -d "./_html/_animations" ]; then mkdir ./_html/_animations; fi
-  if ! cp ./.animations/* ./_html/_animations/; then AN_ERROR_OCCURED=1; finish_up; return; fi
+  
+  if [ -d "./animations" ]; then
+    if [ ! -d "./_html/_animations" ]; then mkdir ./_html/_animations; fi
+    if ! cp ./.animations/* ./_html/_animations/; then AN_ERROR_OCCURED=1; finish_up; return; fi
+  fi
   
   cd .. || exit 1
   


### PR DESCRIPTION
Fixes #353 

My contribution is licensed under the MIT license.

